### PR TITLE
Release v0.3.0

### DIFF
--- a/apps/chau7-macos/Scripts/extract-changelog
+++ b/apps/chau7-macos/Scripts/extract-changelog
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Extract the changelog section for a given version from docs/CHANGELOG.md.
+# Prints the section body (everything between `## [VERSION]` and the next `## [`)
+# without the heading itself, so it can be embedded under a custom header.
+#
+# Usage: extract-changelog <version>
+#   e.g. extract-changelog 0.3.0
+set -euo pipefail
+
+VERSION="${1:?Usage: extract-changelog VERSION}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHANGELOG="${SCRIPT_DIR}/../docs/CHANGELOG.md"
+
+if [ ! -f "$CHANGELOG" ]; then
+  echo "extract-changelog: CHANGELOG not found at $CHANGELOG" >&2
+  exit 1
+fi
+
+awk -v v="$VERSION" '
+  BEGIN { capture = 0 }
+  /^## \[/ {
+    if (capture) { exit }
+    pattern = "^## \\[" v "\\]"
+    if ($0 ~ pattern) { capture = 1; next }
+  }
+  capture { print }
+' "$CHANGELOG"

--- a/apps/chau7-macos/docs/CHANGELOG.md
+++ b/apps/chau7-macos/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-17
+
 ### Added
 - **Grapheme-Cluster-Aware Terminal Model**: The Rust→Swift FFI snapshot now ships UTF-8 grapheme cluster bytes alongside the cell array, so ZWJ emoji (`👨🏽‍💻`), regional-indicator flags (`🇫🇷`), VS16 emoji presentation (`❤️ ✈️`), and NFD-decomposed sequences (`e + ́` → `é`) all survive end-to-end instead of being truncated to their first codepoint. Cell layout (`width`, `continuation`) is now explicit from Rust's `WIDE_CHAR` / `WIDE_CHAR_SPACER` flags — the Metal renderer no longer probes glyph advance to decide cell span, and wide glyphs tile correctly across two cells. NFC normalization runs in the snapshot loop via the `unicode-normalization` crate, so decomposed and precomposed forms share one atlas slot. The Metal glyph atlas is re-keyed by cluster bytes (`Data`) instead of codepoint; multi-codepoint clusters share a single atlas slot. The fragment shader gains a `colorGlyphFlag` (bit 12) branch that samples color-bitmap atlas slots (sbix / COLR / CBDT) directly as RGBA, with the per-glyph detection helper (`isColorGlyph`) left as a focused follow-up. Remote-snapshot wire format bumped CHG1 v1 → CHG2 v2 to carry the cluster buffer; iOS playback updated to match.
 


### PR DESCRIPTION
## Summary
- Cut a `## [0.3.0] - 2026-05-17` section from the `[Unreleased]` block in `apps/chau7-macos/docs/CHANGELOG.md`.
- Restore the missing `apps/chau7-macos/Scripts/extract-changelog` helper that `.github/workflows/release.yml` calls to populate the release body from `CHANGELOG.md`.

## Version rationale
Last tagged release is `v0.2.1`. Minor bump (`0.3.0`) reflects substantial new feature surface in the Unreleased block:

- Grapheme-cluster-aware Rust→Swift terminal FFI (ZWJ emoji, regional flags, NFD sequences preserved end-to-end; CHG1 → CHG2 wire format).
- Per-repository proxy prompt injection (`~/.chau7/prompt-rules.json`, all four upstream providers).
- MCP observer contract: snapshot, subscription feed, replay bounds, heartbeat.
- Spanish (`es`) locale.
- Adaptive render-loop throttling + tier-based graphics memory release.
- Plus a long list of Metal / restore / scrollback / Codex fixes (see CHANGELOG).

## Cutting the release after merge
Tag pushes are blocked from this environment (`HTTP 403` at the git proxy), and the GitHub MCP surface here does not expose release/tag creation. To trigger the release workflow once this is merged, either:

```bash
git tag -a v0.3.0 -m "v0.3.0 — Grapheme-Aware Terminal, Per-Repo Prompt Injection & MCP Observability"
git push origin v0.3.0
```

…or use **Releases → Draft a new release** in the GitHub UI, target the merge commit, choose new tag `v0.3.0`, and click Publish (the workflow listens on `push: tags: 'v*'`).

## Test plan
- [x] Local dry-run of `Scripts/extract-changelog 0.3.0` returns the new section body (264 lines).
- [ ] On tag push, `release.yml` builds the DMG/ZIP/PKG, generates SLSA attestations, creates the release with extracted notes, and updates the Homebrew tap.

https://claude.ai/code/session_01He4PWyYCfPyeeMAosKDV6P

---
_Generated by [Claude Code](https://claude.ai/code/session_01He4PWyYCfPyeeMAosKDV6P)_