### PR TITLE
chore(deps-dev): bump typescript 5.9.3 → 6.0.3 in services/chau7-relay (supersedes #19)

### DIFF
--- a/services/chau7-relay/package-lock.json
+++ b/services/chau7-relay/package-lock.json
@@ -8,7 +8,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "4.20260619.1",
         "prettier": "3.8.4",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "wrangler": "4.103.0"
       },
       "engines": {
@@ -697,9 +697,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -717,9 +714,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -737,9 +731,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -757,9 +748,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -777,9 +765,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -797,9 +782,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -817,9 +799,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -837,9 +816,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -857,9 +833,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -883,9 +856,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -909,9 +879,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -935,9 +902,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -961,9 +925,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -987,9 +948,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1013,9 +971,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1039,9 +994,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1453,9 +1405,9 @@
       "optional": true
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/services/chau7-relay/package.json
+++ b/services/chau7-relay/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "4.20260619.1",
     "prettier": "3.8.4",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "wrangler": "4.103.0"
   }
 }


### PR DESCRIPTION
## Summary
- Rebases #19's TypeScript bump onto current main so the merge no longer reverts the wrangler 4.103.0 and workers-types 4.20260619.1 bumps that landed in #51 / #50.
- TS 6.0.3 typecheck on the relay sources passes clean.
- `wrangler deploy --dry-run` succeeds with the new compiler.

Closes #19.

## Test plan
- [x] `npm install` in `services/chau7-relay` — 0 vulnerabilities
- [x] `npm run typecheck` — pass
- [x] `npm run build` (wrangler dry-run) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)